### PR TITLE
Support api return void

### DIFF
--- a/envi/__init__.py
+++ b/envi/__init__.py
@@ -1186,13 +1186,14 @@ class CallingConvention(object):
         self.setupCall(emu, args=args, ra=ra)
         emu.setProgramCounter(va)
 
-    def execCallReturn(self, emu, value, argc):
+    def execCallReturn(self, emu, value, argc, apiReturnsVoid=False):
         '''
         Forces a function to return the specified value.
 
         Reads the return address from the stack, deallocates the stack space
-        allocated for the call, sets the return value, and sets the program
-        counter to the previously read return address.
+        allocated for the call, sets the return value (unless apiReturnsVoid
+        is True), and sets the program counter to the previously read
+        return address.
 
         Expects to be called at the function entrypoint.
         '''
@@ -1200,7 +1201,8 @@ class CallingConvention(object):
         ip = self.getReturnAddress(emu)
         self.deallocateCallSpace(emu, argc)
 
-        self.setReturnValue(emu, value)
+        if not apiReturnsVoid:
+            self.setReturnValue(emu, value)
         emu.setProgramCounter(ip)
 
 # NOTE: This mapping is needed because of inconsistancies

--- a/vivisect/impemu/emulator.py
+++ b/vivisect/impemu/emulator.py
@@ -182,10 +182,12 @@ class WorkspaceEmulator:
 
             else:
 
+                apiRetVoid = (ret == None) and (callname != None) \
+                             and (rtype == 'void')
                 if ret == None:
                     ret = self.setVivTaint('apicall', (op,endeip,api,argv))
 
-                callconv.execCallReturn( self, ret, len(funcargs) )
+                callconv.execCallReturn(self, ret, len(funcargs), apiRetVoid)
 
             # Either way, if it's a call PC goes to next instruction
             if self._func_only:

--- a/vivisect/symboliks/analysis.py
+++ b/vivisect/symboliks/analysis.py
@@ -237,6 +237,18 @@ class SymbolikFunctionEmulator(vsym_emulator.SymbolikEmulator):
                     if funccb != None:
                         fret = funccb(self, thunk, symargs)
 
+            # If calling convention is defined, then API will also be defined.
+            # Set the return state if there is one.                              
+            if (cconv != None) and \
+               not ((apictx[API_FUNC_NAME] != None) \
+                    and (apictx[API_RET_TYPE] == 'void')):
+                if fret == None:
+                    # TODO: yuck. take ez way out and use width on emu.          
+                    # should get return val def from cc and set width according  
+                    # to width of that?                                          
+                    fret = Call(funcsym, self.__width__, symargs)
+                cconv.setSymbolikReturn(self, fret, argv, precall=True)
+
         else:
 
             funcname = str(funcsym)     # Not necessarily the name but...
@@ -251,7 +263,6 @@ class SymbolikFunctionEmulator(vsym_emulator.SymbolikEmulator):
                 argv = (('int', None), ('int', None), ('int', None), ('int', None))
                 apidef = ( 'int', None, defcall, funcname, argv)
 
-            #( 'int', None, 'stdcall', 'wininet.FindFirstUrlCacheContainerW', (('int', None), ('void *', 'ptr'), ('int', None), ('int', None)) ),
             rt,rn,cc,fn,argv = apidef
             cconv = self.getCallingConvention( cc )
 
@@ -264,14 +275,15 @@ class SymbolikFunctionEmulator(vsym_emulator.SymbolikEmulator):
             if funccb != None:
                 fret = funccb(self, funcname, symargs)
 
-        # If we have a calling convention here, set the return state
-        if cconv != None:
-            if fret == None:
-                # TODO: yuck. take ez way out and use width on emu.
-                # should get return value def from cc and set width according
-                # to width of that?
-                fret = Call(funcsym, self.__width__, symargs)
-            cconv.setSymbolikReturn(self, fret, argv, precall=True)
+            # Set the return state if there is one.
+            if (cconv != None) and \
+               not ((fn != None) and (rt == 'void')):
+                if fret == None:
+                    # TODO: yuck. take ez way out and use width on emu.
+                    # should get return value def from cc and set width according
+                    # to width of that?
+                    fret = Call(funcsym, self.__width__, symargs)
+                cconv.setSymbolikReturn(self, fret, argv, precall=True)
 
         return symargs
 


### PR DESCRIPTION
If an API definition returns void, then do not set a return value (e.g., for PE files, do not set eax/rax). Changes apply to both machine emulation and symbolik execution.